### PR TITLE
Added header guard to the main header file

### DIFF
--- a/Adafruit_VC0706.h
+++ b/Adafruit_VC0706.h
@@ -15,6 +15,8 @@
  ****************************************************/
 
 
+#ifndef ADAFRUIT_VC0706
+#define ADAFRUIT_VC0706
 #if ARDUINO >= 100
  #include "Arduino.h"
  #include "SoftwareSerial.h"
@@ -115,3 +117,4 @@ class Adafruit_VC0706 {
   boolean verifyResponse(uint8_t command);
   void printBuff(void);
 };
+#endif


### PR DESCRIPTION
I was running into issues while attempting to compile my sketch that needed to access the Adafruit_VC0706 class in multiple files, so I needed to include them twice.

Got it working by simply adding a header guard to the main header. Hopefully this might help someone else in the future.
