### PR TITLE
[#16] Increase baud variable size to allow holding 115200.

### DIFF
--- a/Adafruit_VC0706.cpp
+++ b/Adafruit_VC0706.cpp
@@ -47,7 +47,7 @@ Adafruit_VC0706::Adafruit_VC0706(HardwareSerial *ser) {
   hwSerial = ser; // ...override hwSerial with value passed.
 }
 
-boolean Adafruit_VC0706::begin(uint16_t baud) {
+boolean Adafruit_VC0706::begin(uint32_t baud) {
 #if not defined (_VARIANT_ARDUINO_DUE_X_) && not defined (_VARIANT_ARDUINO_ZERO_)
   if(swSerial) swSerial->begin(baud);
   else

--- a/Adafruit_VC0706.h
+++ b/Adafruit_VC0706.h
@@ -73,7 +73,7 @@ class Adafruit_VC0706 {
   #endif
 #endif
   Adafruit_VC0706(HardwareSerial *ser); // Constructor when using HardwareSerial
-  boolean begin(uint16_t baud = 38400);
+  boolean begin(uint32_t baud = 38400);
   boolean reset(void);
   boolean TVon(void);
   boolean TVoff(void);


### PR DESCRIPTION
This is a fix for the issue described in issue #16. I increased the size of the baud variable from 16 bits to 32 bits to allow it to hold a baud rate value of 115200.