### PR TITLE
work around readPicture short read glitch

### DIFF
--- a/Adafruit_VC0706.h
+++ b/Adafruit_VC0706.h
@@ -108,6 +108,7 @@ private:
   uint8_t camerabuff[CAMERABUFFSIZ + 1];
   uint8_t bufferLen;
   uint16_t frameptr;
+  uint16_t glitchBytes = 0;
 
 #if defined(__AVR__) || defined(ESP8266)
   SoftwareSerial *swSerial;


### PR DESCRIPTION
In some situations, the data returned will be short a byte. That byte will show up on all subsequent requests as if a buffer within the camera is simply off by one. But then it can happen again and the buffer will be off by more bytes.

This change will deal with up to 5 such glitches by assuming we don't really need the trailer data.

I don't know if this is worth merging as the situation must somehow being completely dependent on the combination of hardware I'm using. If this was happening to others the camera would be totally useless.

I'm mainly putting this here in the hopes of maybe finding someone else who has experienced this. Maybe there is a better workaround? Or perhaps my camera is broken.

This was tested with a Arduino Nano 33 BLE using modified example code to dump base64 image data over the serial link. https://gist.github.com/rhettg/7d06ef5a08a11b45aa1a65104774c341
