### PR TITLE
Fix missing return in setMotion Detect

### DIFF
--- a/Adafruit_VC0706.cpp
+++ b/Adafruit_VC0706.cpp
@@ -138,7 +138,7 @@ boolean Adafruit_VC0706::setMotionDetect(boolean flag) {
 
   uint8_t args[] = {0x01, flag};
 
-  runCommand(VC0706_COMM_MOTION_CTRL, args, sizeof(args), 5);
+  return runCommand(VC0706_COMM_MOTION_CTRL, args, sizeof(args), 5);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
The missing return statement caused an error when compiling for SAMD21 with latest Arduino IDE.

```
C:\Users\User\Documents\Arduino\libraries\Adafruit_VC0706_Serial_Camera_Library\Adafruit_VC0706.cpp:
In member function 'boolean Adafruit_VC0706::setMotionDetect(boolean)':
C:\Users\User\Documents\Arduino\libraries\Adafruit_VC0706_Serial_Camera_Library\Adafruit_VC0706.cpp:141:13:
error: control reaches end of non-void function [-Werror=return-type]
141 |   runCommand(VC0706_COMM_MOTION_CTRL, args, sizeof(args), 5);
       |   ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus.exe: some warnings being treated as errors
exit status 1
Error compiling for board Adafruit Feather M0 (SAMD21).
```


