### PR TITLE
Add parameter to set delay time in readPicture()

### DIFF
--- a/Adafruit_VC0706.cpp
+++ b/Adafruit_VC0706.cpp
@@ -544,7 +544,7 @@ uint8_t Adafruit_VC0706::available(void) { return bufferLen; }
     @returns Pointer to buffer containing n bytes of picture data
 */
 /**************************************************************************/
-uint8_t *Adafruit_VC0706::readPicture(uint8_t n) {
+uint8_t *Adafruit_VC0706::readPicture(uint8_t n, uint32_t delay_time) {
   uint8_t args[] = {0x0C,
                     0x0,
                     0x0A,
@@ -556,14 +556,17 @@ uint8_t *Adafruit_VC0706::readPicture(uint8_t n) {
                     0,
                     0,
                     n,
-                    CAMERADELAY >> 8,
-                    CAMERADELAY & 0xFF};
+                    delay_time >> 8,
+                    delay_time & 0xFF};
 
   if (!runCommand(VC0706_READ_FBUF, args, sizeof(args), 5, false))
+  {
+    Serial.println("VC0706: Read fbuf failed - delay time too small?");
     return 0;
+  }
 
   // read into the buffer PACKETLEN!
-  if (readResponse(n + 5, CAMERADELAY) == 0)
+  if (readResponse(n + 5, delay_time) == 0)
     return 0;
 
   frameptr += n;

--- a/Adafruit_VC0706.cpp
+++ b/Adafruit_VC0706.cpp
@@ -559,8 +559,7 @@ uint8_t *Adafruit_VC0706::readPicture(uint8_t n, uint32_t delay_time) {
                     delay_time >> 8,
                     delay_time & 0xFF};
 
-  if (!runCommand(VC0706_READ_FBUF, args, sizeof(args), 5, false))
-  {
+  if (!runCommand(VC0706_READ_FBUF, args, sizeof(args), 5, false)) {
     Serial.println("VC0706: Read fbuf failed - delay time too small?");
     return 0;
   }

--- a/Adafruit_VC0706.cpp
+++ b/Adafruit_VC0706.cpp
@@ -541,6 +541,7 @@ uint8_t Adafruit_VC0706::available(void) { return bufferLen; }
 /*!
     @brief Read in picture data
     @param n Number of bytes
+    @param delay_time The camera's delay time between command and data. 
     @returns Pointer to buffer containing n bytes of picture data
 */
 /**************************************************************************/

--- a/Adafruit_VC0706.cpp
+++ b/Adafruit_VC0706.cpp
@@ -541,7 +541,7 @@ uint8_t Adafruit_VC0706::available(void) { return bufferLen; }
 /*!
     @brief Read in picture data
     @param n Number of bytes
-    @param delay_time The camera's delay time between command and data. 
+    @param delay_time The camera's delay time between command and data
     @returns Pointer to buffer containing n bytes of picture data
 */
 /**************************************************************************/

--- a/Adafruit_VC0706.h
+++ b/Adafruit_VC0706.h
@@ -79,7 +79,7 @@ public:
   boolean TVon(void);
   boolean TVoff(void);
   boolean takePicture(void);
-  uint8_t *readPicture(uint8_t n);
+  uint8_t *readPicture(uint8_t n, uint32_t delay_time = CAMERADELAY);
   boolean resumeVideo(void);
   uint32_t frameLength(void);
   char *getVersion(void);


### PR DESCRIPTION
This change relates to issue #21.  I saw a similar issue where it was necessary to increase the CAMERADELAY value from 10 to 32 in order to successfully read data from the cameras.   

Following taf2's suggestion, this pull request adds a parameter to the readPicture() function to allow overriding the default CAMERADELAY value.  By default the code will work as before using the CAMERADELAY value of 10.  I have also added an error message to help users identify when increasing the delay time may be required.

I haven't been able to find a root cause for why increasing the delay time is sometimes necessary but it has  helped in my setup and may help others.

I have tested the changes with my setup (ESP32 and two VC0706 cameras).

Best regards,
Phil

